### PR TITLE
コマンドのレスポンスを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ make deploy
 | /akashi 退勤 | 退勤を打刻します。                                                                                                             |
 ※Slash CommandのCommandを`akashi`とした場合を想定。
 
+## 運用
+トークンの期限切れた場合は、手動で再発行し、Spreadsheetの各自のトークンを更新する必要がある。
+Akashiのトークンの有効期限は発行から1ヶ月であるため、月1回の更新が必要となる。
+トークン再発行の自動化については以下issue参照。
+cf. https://github.com/bmf-san/akashi-slack-slash-command/issues/6
+
 # コスト
 [Cloud Functions - Cloudfunctionsの料金](https://cloud.google.com/functions/pricing?hl=ja)
 


### PR DESCRIPTION
# 概要
成功・失敗時のレスポンスを調整する。
この対応が完了したら運用可能なバージョンとして1.0.0のtagを切ってリリース。

# 対応
- [x] 正常系レスポンスの調整
- [x] 異常系レスポンスの調整

# memo
トークン切れエラーレスポンス例
```json
{
   "success": false,
   "errors": [
       {
           "code": "ERR300003",
           "message": "指定されたトークンの期限が切れています。再度トークンを発行してください。"
       }
   ]
}
```

# Issue
https://github.com/bmf-san/akashi-slack-slash-command/issues/7